### PR TITLE
fix error message for warp 10 3.x

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -45,7 +45,7 @@ export class Utils {
         if (xmlHttp.readyState === 4 && xmlHttp.status === 200) {
           resolve({data: xmlHttp.responseText, headers: xmlHttp.getAllResponseHeaders()});
         } else if (xmlHttp.readyState === 4 && xmlHttp.status >= 400) {
-          reject(xmlHttp.getResponseHeader('X-Warp10-Error-Message'))
+          reject(xmlHttp.getResponseHeader('X-Warp10-Error-Message') || xmlHttp.statusText);
         }
       };
       xmlHttp.open('POST', theUrl, true); // true for asynchronous

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -45,7 +45,7 @@ export class Utils {
         if (xmlHttp.readyState === 4 && xmlHttp.status === 200) {
           resolve({data: xmlHttp.responseText, headers: xmlHttp.getAllResponseHeaders()});
         } else if (xmlHttp.readyState === 4 && xmlHttp.status >= 400) {
-          reject(xmlHttp.statusText)
+          reject(xmlHttp.getResponseHeader('X-Warp10-Error-Message'))
         }
       };
       xmlHttp.open('POST', theUrl, true); // true for asynchronous


### PR DESCRIPTION
Not the same error 500 page, so it is better to rely on the dedicated header for error message.

warp 10 2.x
```
<html>
<head>
<meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>
<title>Error 500 ERROR line #4: Exception at &apos;&apos;dtc&apos; =&gt;MSGFAIL&lt;= 1 4 &lt;%&apos; in section [TOP] (MSGFAIL dtc)</title>
</head>
<body><h2>HTTP ERROR 500</h2>
<p>Problem accessing /api/v0/exec. Reason:
<pre>    ERROR line #4: Exception at &apos;&apos;dtc&apos; =&gt;MSGFAIL&lt;= 1 4 &lt;%&apos; in section [TOP] (MSGFAIL dtc)</pre></p>
</body>
</html>
```

warp 10 3.x
```
<html>
<head>
<meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1"/>
<title>Error 500 ERROR line #4: Exception at &apos;&apos;dtc&apos; =&gt;MSGFAIL&lt;= 1 4 &lt;% DROP NEWGTS &apos;g&apos; STORE&apos; in section [TOP] (MSGFAIL dtc)</title>
</head>
<body><h2>HTTP ERROR 500 ERROR line #4: Exception at &apos;&apos;dtc&apos; =&gt;MSGFAIL&lt;= 1 4 &lt;% DROP NEWGTS &apos;g&apos; STORE&apos; in section [TOP] (MSGFAIL dtc)</h2>
<table>
<tr><th>URI:</th><td>/api/v0/exec</td></tr>
<tr><th>STATUS:</th><td>500</td></tr>
<tr><th>MESSAGE:</th><td>ERROR line #4: Exception at &apos;&apos;dtc&apos; =&gt;MSGFAIL&lt;= 1 4 &lt;% DROP NEWGTS &apos;g&apos; STORE&apos; in section [TOP] (MSGFAIL dtc)</td></tr>
<tr><th>SERVLET:</th><td>-</td></tr>
</table>

</body>
</html>
```